### PR TITLE
Factorio 2.0.11 support

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -48,7 +48,7 @@ function process(event, debug, print)
 		local logistic_systems = get_logistic_systems(event, exported_entities, exported_entities_map, print)
 
 		if not debug then
-			game.write_file('exported-entities.json',
+			helpers.write_file('exported-entities.json',
 				serialize(export_schema, {
 					entities = exported_entities,
 					bounds = bounds,

--- a/control.lua
+++ b/control.lua
@@ -35,8 +35,9 @@ function process(event, debug, print)
 		print('Bounds')
 		local bounds = get_bounds(exported_entities)
 
-		print('Wire connection')
-		local wire_connections = get_wire_connections(event)
+		-- print('Wire connection')
+		-- local wire_connections = get_wire_connections(event)
+		-- Removed wire connections for now, as it causes problems, that I have no idea how to fix lol
 
 		print('Train paths')
 		local train_paths = get_train_paths(event, exported_entities, exported_entities_map, print)

--- a/data.lua
+++ b/data.lua
@@ -11,34 +11,34 @@ data:extend(
 			flags = { "icon" }
 		}
 	},
-	{
-		type = "selection-tool",
-		name = "FUE5Exporter__export-selector",
-		icon = "__base__/graphics/icons/signal/signal_E.png",
-		icon_size = 64,
-		subgroup = "tool",
-		stack_size = 1,
-		stackable = false,
-		draw_label_for_cursor_render = true,
-		selection_color = { r = 0, g = 0, b = 1 },
-		alt_selection_color = { r = 1, g = 0, b = 0 },
-		flags = { "only-in-cursor" },
-		selection_mode = { "any-entity" },
-		alt_selection_mode = { "any-entity" },
-		selection_cursor_box_type = "entity",
-		alt_selection_cursor_box_type = "entity",
-		entity_filter_mode = "blacklist",
-		entity_type_filters = {
-			"character",
-			"resource",
-			"spider-leg"
-		},
-		alt_entity_filter_mode = "blacklist",
-		alt_entity_type_filters = {
-			"character",
-			"resource",
-			"spider-leg"
-		}
-	}
+    {
+        type = "selection-tool",
+        name = "FUE5Exporter__export-selector",
+        icon = "__base__/graphics/icons/signal/signal_E.png",
+        icon_size = 64,
+        subgroup = "tool",
+        stack_size = 1,
+        stackable = false,
+        draw_label_for_cursor_render = true,
+        
+        -- New properties introduced in Factorio 2.0
+        select = {
+            selection_color = { r = 0, g = 0, b = 1 },
+            selection_cursor_box_type = "entity",
+            entity_filter_mode = "blacklist",
+            entity_type_filters = { "character", "resource", "spider-leg" }
+        },
+        alt_select = {
+            selection_color = { r = 1, g = 0, b = 0 },
+            selection_cursor_box_type = "entity",
+            entity_filter_mode = "blacklist",
+            entity_type_filters = { "character", "resource", "spider-leg" }
+        },
+        
+        -- Optional properties
+        always_include_tiles = false,
+        mouse_cursor = "selection-tool-cursor",
+        skip_fog_of_war = false
+    }
 })
 

--- a/data.lua
+++ b/data.lua
@@ -4,12 +4,8 @@ data:extend(
 		type = "shortcut",
 		name = "FUE5Exporter__export-entities",
 		action = "lua",
-		icon = {
-		filename = "__base__/graphics/icons/signal/signal_E.png",
-		size = 64,
-			scale = 1,
-			flags = { "icon" }
-		}
+		icon = "__base__/graphics/icons/signal/signal_E.png",
+		icon_size = 64
 	},
     {
         type = "selection-tool",

--- a/data.lua
+++ b/data.lua
@@ -23,14 +23,16 @@ data:extend(
         
         -- New properties introduced in Factorio 2.0
         select = {
-            selection_color = { r = 0, g = 0, b = 1 },
-            selection_cursor_box_type = "entity",
+            border_color = { r = 0, g = 0, b = 1 },
+            mode = "any-entity",
+            cursor_box_type = "entity",
             entity_filter_mode = "blacklist",
             entity_type_filters = { "character", "resource", "spider-leg" }
         },
         alt_select = {
-            selection_color = { r = 1, g = 0, b = 0 },
-            selection_cursor_box_type = "entity",
+            border_color = { r = 1, g = 0, b = 0 },
+            mode = "any-entity",
+            cursor_box_type = "entity",
             entity_filter_mode = "blacklist",
             entity_type_filters = { "character", "resource", "spider-leg" }
         },

--- a/data.lua
+++ b/data.lua
@@ -5,7 +5,9 @@ data:extend(
 		name = "FUE5Exporter__export-entities",
 		action = "lua",
 		icon = "__base__/graphics/icons/signal/signal_E.png",
-		icon_size = 64
+		icon_size = 64,
+		small_icon = "__base__/graphics/icons/signal/signal_E.png",
+		small_icon_size = 64
 	},
     {
         type = "selection-tool",

--- a/info.json
+++ b/info.json
@@ -5,7 +5,7 @@
   "author": "Atria",
   "contact": "tomas.chmelik2@gmail.com",
   "homepage": "https://github.com/FUE5BASE/FUE5Exporter",
-  "factorio_version": "1.1",
-  "dependencies": ["base >= 1.1"],
+  "factorio_version": "2.0.11",
+  "dependencies": ["base >= 2.0.11"],
   "description": "Adds selection tool for exporting bases to json readable by FUE5"
 }

--- a/info.json
+++ b/info.json
@@ -5,7 +5,7 @@
   "author": "Atria",
   "contact": "tomas.chmelik2@gmail.com",
   "homepage": "https://github.com/FUE5BASE/FUE5Exporter",
-  "factorio_version": "2.0.11",
+  "factorio_version": "2.0",
   "dependencies": ["base >= 2.0.11"],
   "description": "Adds selection tool for exporting bases to json readable by FUE5"
 }


### PR DESCRIPTION
I fixed some files up that gave errors when trying to load the mod in new factorio. I disabled wire connections from being saved, as I have no idea how it works. I have never used factorio, just tried fixing some things while looking at the docs. This mod was tested and is working for the most part. After trying to render them in the FUE5, some things like items on belts and some other entities like fish and biters are broken and do not render. So this code makes it possible to load the mod in the new version, and works the exact same as before, except for the wires thing mentioned above.